### PR TITLE
Add Pandoc backend for multi-format rendering (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-02-22
+
+### Added
+- **Pandoc backend**: Markdown becomes the source of truth, with multi-format output (docx, pdf, html, epub, pptx) via pypandoc
+- `will render` CLI command with options: `-o/--output`, `-f/--format` (multiple), `-t/--template`, `-V/--var` (KEY=VALUE), `--backend` (pandoc/legacy)
+- `src/will/render.py` — render pipeline: input detection → spec compilation → frontmatter extraction → variable preprocessing → Pandoc conversion
+- `src/will/pandoc_backend.py` — thin pypandoc wrapper with format-specific defaults (pdf-engine, embed-resources, standalone)
+- `src/will/preprocess.py` — Jinja2-based `{{var}}` substitution with passthrough undefined (unresolved vars remain as-is)
+- `src/will/spec_compiler.py` — compiles legacy YAML/JSON specs to Markdown+frontmatter for backward compatibility
+- Pandoc defaults files: `templates/defaults/docx.yaml`, `pdf.yaml`, `html.yaml`
+- `examples/report.md` — Markdown equivalent of `examples/report.yaml` with YAML frontmatter
+- Test suites: `test_render.py`, `test_preprocess.py`, `test_spec_compiler.py`, `test_pandoc_backend.py`
+
+### Changed
+- Bumped version to 0.2.0
+- `requires-python` raised to `>=3.10`
+- Added `pypandoc-binary>=1.15` and `jinja2>=3.0` to dependencies
+- Updated keywords and classifiers for multi-format support
+
+### Backward Compatibility
+- Legacy `will generate` command and python-docx backend remain fully functional
+- Legacy YAML/JSON spec format accepted and compiled to Markdown internally
+- Use `--backend legacy` to force the python-docx backend
+
 ## [0.1.1] - 2026-01-12
 
 ### Added
@@ -33,5 +57,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker support and GCP Cloud Run deployment
 - MkDocs documentation with Material theme
 
+[0.2.0]: https://github.com/yanndebray/schopenhauer/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/yanndebray/schopenhauer/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/yanndebray/schopenhauer/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,442 @@
+# CLAUDE.md — Schopenhauer
+
+> This file guides Claude Code when working on the Schopenhauer project.
+> It describes the current state, the target architecture, and the migration path.
+
+## Project Identity
+
+**Schopenhauer** — "The Will to Document"
+A CLI tool and Python library for generating professional documents from Markdown sources.
+Part of the philosopher-named tools ecosystem (nietzsche.cc, montaigne.cc, ricoeur.cc).
+
+- **Package name:** `schopenhauer`
+- **CLI command:** `will`
+- **Website:** schopenhauer.cc
+- **PyPI:** `pip install schopenhauer`
+- **License:** MIT
+
+## Architecture Transition
+
+### Where we are (v0.1.x — Legacy)
+
+The current implementation uses python-docx to render YAML/JSON specs into .docx files.
+This approach is being **retired**. Do not add features to the python-docx backend.
+
+```
+YAML spec → python-docx → .docx only
+```
+
+Key legacy files (to be replaced):
+- `src/will/` — current python-docx based engine
+- YAML spec format with `sections:` array defining document structure
+- `WordDocument` class and `DocumentBuilder` fluent API
+- Direct style manipulation via python-docx
+
+### Where we're going (v0.2+ — Pandoc Backend)
+
+Markdown becomes the source of truth. Schopenhauer becomes an orchestration layer
+on top of Pandoc (via pypandoc_binary), similar to how Quarto wraps Pandoc for
+scientific publishing — but optimized for programmatic and AI-agent use cases.
+
+```
+Markdown + YAML frontmatter
+        ↓
+  Schopenhauer (preprocessing: data binding, template resolution, includes)
+        ↓
+  Pandoc (via pypandoc_binary)
+        ↓
+  .docx / .pdf / .html / .pptx / .epub / .latex
+```
+
+### Core Principle
+
+**Schopenhauer does not render documents. Pandoc renders documents.**
+Schopenhauer owns: the spec format, preprocessing, templates, data binding, CLI, API, and MCP server.
+Pandoc owns: parsing Markdown, applying styles, producing output files.
+
+---
+
+## Target Architecture (v0.2)
+
+### Source Format: Markdown with YAML Frontmatter
+
+The canonical input is a `.md` file with YAML frontmatter. This is the source of truth.
+
+```markdown
+---
+title: "Quarterly Report"
+subtitle: "Q4 2024 Results"
+author: "Analytics Team"
+date: "2024-12-15"
+will:
+  template: report
+  output:
+    - docx
+    - pdf
+  data:
+    metrics: data/q4_metrics.csv
+  variables:
+    quarter: Q4
+    year: 2024
+---
+
+# Executive Summary
+
+This report covers **{{quarter}} {{year}}** performance across all divisions.
+
+# Key Metrics
+
+{{table:metrics, columns=[Metric, Value, Change]}}
+
+# Team Updates
+
+{{for member in team}}
+## {{member.name}} — {{member.role}}
+
+{{member.summary}}
+{{endfor}}
+```
+
+**Design decisions:**
+- Standard YAML frontmatter for Pandoc-native fields (title, author, date, etc.)
+- `will:` namespace in frontmatter for Schopenhauer-specific config (template, output formats, data sources, variables)
+- `{{variable}}` syntax for simple variable substitution (preprocessed before Pandoc)
+- `{{table:source}}`, `{{for}}`, `{{if}}` for data binding directives (preprocessed before Pandoc)
+- Raw Markdown passes through to Pandoc unchanged — any valid Pandoc Markdown works
+
+### YAML Spec Compatibility Layer
+
+The legacy YAML spec format is still accepted but compiled to Markdown internally.
+This is important for backward compatibility and for AI agents that emit structured JSON/YAML.
+
+```bash
+# These are equivalent:
+will render report.md -o report.docx
+will render spec.yaml -o report.docx       # compiled to markdown first
+echo '{"title":"Report",...}' | will render --stdin -o report.docx
+```
+
+A JSON Schema is published for both the YAML spec format and the frontmatter schema
+so LLMs can validate specs before submission.
+
+### Directory Structure (Target)
+
+```
+schopenhauer/
+├── CLAUDE.md                    # This file
+├── README.md
+├── pyproject.toml
+├── LICENSE
+├── Dockerfile
+├── deploy.sh
+├── mkdocs.yml
+│
+├── src/will/
+│   ├── __init__.py              # Public API: render(), convert(), Document class
+│   ├── cli.py                   # Click CLI (will command)
+│   ├── render.py                # Core render pipeline: preprocess → pandoc → output
+│   ├── preprocess.py            # Data binding, variable substitution, includes, loops
+│   ├── pandoc_backend.py        # pypandoc wrapper, filter management, format options
+│   ├── templates.py             # Template registry: resolve names → reference docs
+│   ├── spec_compiler.py         # YAML/JSON spec → Markdown compiler (compat layer)
+│   ├── schema.py                # JSON Schema definitions for spec + frontmatter
+│   ├── api.py                   # FastAPI REST API (format-agnostic)
+│   ├── mcp.py                   # MCP server (generate, inspect, list_templates, convert)
+│   └── filters/                 # Lua filters for Pandoc
+│       ├── callouts.lua
+│       └── branded.lua
+│
+├── templates/                   # Pandoc reference documents and templates
+│   ├── reference-docs/          # .docx reference templates for Pandoc
+│   │   ├── default.docx
+│   │   ├── report.docx
+│   │   ├── memo.docx
+│   │   ├── letter.docx
+│   │   ├── academic.docx
+│   │   ├── proposal.docx
+│   │   └── contract.docx
+│   ├── latex/                   # LaTeX templates for PDF output
+│   │   └── report.tex
+│   ├── html/                    # HTML templates/themes
+│   │   └── default.html
+│   └── defaults/                # Pandoc defaults YAML files
+│       ├── docx.yaml
+│       ├── pdf.yaml
+│       └── html.yaml
+│
+├── schemas/                     # Published JSON Schemas
+│   ├── frontmatter.schema.json  # Schema for YAML frontmatter
+│   └── spec.schema.json         # Schema for YAML/JSON spec (compat)
+│
+├── examples/
+│   ├── report.md                # Example: Markdown source document
+│   ├── report-spec.yaml         # Example: Legacy YAML spec
+│   ├── data/                    # Example data files
+│   └── multi-format/            # Example: one source → multiple outputs
+│
+├── tests/
+│   ├── test_render.py
+│   ├── test_preprocess.py
+│   ├── test_spec_compiler.py
+│   ├── test_templates.py
+│   ├── test_cli.py
+│   ├── test_api.py
+│   └── fixtures/
+│
+├── docs/                        # MkDocs documentation
+│   ├── index.md
+│   ├── getting-started.md
+│   ├── markdown-format.md
+│   ├── templates.md
+│   ├── data-binding.md
+│   ├── multi-format.md
+│   ├── api-reference.md
+│   ├── mcp-server.md
+│   └── migration-from-v01.md
+│
+└── website/                     # Landing page (schopenhauer.cc)
+```
+
+---
+
+## Migration Path
+
+### Phase 1: Pandoc Backend (v0.2.0)
+
+**Goal:** Add pypandoc as a rendering backend. Markdown in, multi-format out. Keep legacy working.
+
+1. Add `pypandoc_binary` to dependencies in pyproject.toml
+2. Create `src/will/pandoc_backend.py`:
+   - Thin wrapper around pypandoc
+   - Accepts a Markdown string + frontmatter dict → renders to target format
+   - Manages reference doc paths, Pandoc options, filters
+3. Create `src/will/render.py`:
+   - `render(source: str | Path, output: str | Path, format: str = "docx")`
+   - Detects input type (.md vs .yaml/.json)
+   - For .md: extract frontmatter, preprocess, pass to pandoc_backend
+   - For .yaml/.json: compile to markdown first (spec_compiler), then same pipeline
+4. Create `src/will/preprocess.py`:
+   - Variable substitution: `{{var}}` → resolved value
+   - Start simple, expand later
+5. Create initial reference docs in `templates/reference-docs/`:
+   - Start with `default.docx` — create a clean Word template with heading styles, etc.
+   - Can use pandoc itself to generate a starter: `pandoc -o default.docx --print-default-data-file reference.docx`
+6. Add CLI commands:
+   - `will render <input> -o <output> -f <format>` (new primary command)
+   - Keep `will generate` as alias pointing to render
+7. Tests:
+   - Test that a simple .md file renders to .docx via pandoc
+   - Test that the same .md renders to .pdf, .html
+   - Test that a legacy .yaml spec still renders (via compilation to markdown)
+
+**Key dependency change in pyproject.toml:**
+```toml
+dependencies = [
+    "click>=8.0",
+    "pyyaml>=6.0",
+    "pypandoc-binary>=1.13",    # replaces python-docx
+    "jinja2>=3.0",              # for preprocessing
+]
+```
+
+**Do not remove python-docx yet.** Keep the old backend available via `--backend legacy` flag during this phase.
+
+### Phase 2: Data Binding & Templates (v0.2.x)
+
+**Goal:** The features that differentiate Schopenhauer from raw Pandoc.
+
+1. Expand `preprocess.py` with Jinja2-powered preprocessing:
+   - `{{for item in collection}}...{{endfor}}` — loop over data
+   - `{{if condition}}...{{endif}}` — conditional sections
+   - `{{include "path/to/section.md"}}` — file includes
+   - `{{table:data_source, columns=[...]}}` — auto-generate Markdown tables from CSV/JSON
+2. Data source loading:
+   - CSV files → list of dicts
+   - JSON files → parsed objects
+   - YAML files → parsed objects
+   - Later: URL fetching, database queries
+3. Template system overhaul:
+   - `will template list` — shows available templates with descriptions
+   - `will template init <name> -o doc.md` — scaffolds a .md file with frontmatter
+   - `will template create` — creates a new reference doc from an existing .docx
+   - Templates resolve by name: `template: report` → finds `templates/reference-docs/report.docx`
+4. Pandoc defaults files:
+   - Each output format has a defaults YAML file (e.g., `templates/defaults/docx.yaml`)
+   - Templates can override defaults
+   - User can provide their own defaults
+
+### Phase 3: Remove Legacy Backend (v0.3.0)
+
+**Goal:** Clean break. python-docx is gone.
+
+1. Remove all python-docx code from `src/will/`
+2. Remove `python-docx` from dependencies
+3. Remove `--backend` flag
+4. Update all examples to use Markdown format
+5. Publish migration guide in docs (`docs/migration-from-v01.md`)
+6. The YAML/JSON spec input still works (via spec_compiler) but is documented as
+   "programmatic input format" rather than the primary authoring format
+
+### Phase 4: Agent Interface & MCP (v0.4.0)
+
+**Goal:** Purpose-built for AI agents and automation.
+
+1. MCP Server (`src/will/mcp.py`):
+   - `generate_document` — accepts spec or markdown, returns rendered file
+   - `list_templates` — returns available templates with schemas
+   - `inspect_document` — reads an existing document, returns structure
+   - `convert_format` — converts between formats via Pandoc
+   - `get_schema` — returns JSON Schema for spec format
+2. JSON Schema publication:
+   - `schemas/frontmatter.schema.json` — validates YAML frontmatter
+   - `schemas/spec.schema.json` — validates YAML/JSON specs
+   - Schemas are versioned and published with the package
+3. Stdin/stdout pipeline support:
+   - `echo "# Hello" | will render -f docx > hello.docx`
+   - `cat spec.json | will render --stdin -f pdf > report.pdf`
+4. REST API updates:
+   - All endpoints become format-agnostic
+   - New `/convert` endpoint for format conversion
+   - OpenAPI schema auto-generated from Pydantic models
+
+---
+
+## CLI Reference (Target)
+
+```bash
+# Primary commands
+will render <input> -o <output>          # Render .md or .yaml to output format
+will render <input> -f docx -f pdf       # Multi-format output
+will render --stdin -f docx > out.docx   # Pipe mode
+
+# Template management
+will template list                        # List available templates
+will template init <name> -o doc.md       # Scaffold a new document
+will template create <name> <file.docx>   # Register a .docx as a reference template
+will template info <name>                 # Show template details
+
+# Conversion (Pandoc passthrough)
+will convert <input> -f <format> -o <output>
+
+# Inspection
+will inspect <file>                       # Show document structure
+
+# Server modes
+will serve                                # Start REST API server
+will mcp                                  # Start MCP server
+
+# Utilities
+will schema                               # Print JSON Schema for spec format
+will schema --frontmatter                  # Print JSON Schema for frontmatter
+```
+
+## Python API (Target)
+
+```python
+from will import render, Document
+
+# Simple render
+render("report.md", output="report.docx")
+render("report.md", output="report.pdf", format="pdf")
+
+# From string
+doc = Document("""
+---
+title: My Report
+will:
+  template: report
+---
+# Introduction
+Hello world.
+""")
+doc.render("report.docx")
+doc.render("report.pdf")
+
+# From YAML spec (backward compat)
+render("spec.yaml", output="report.docx")
+
+# Programmatic construction
+doc = Document()
+doc.frontmatter(title="My Report", template="report")
+doc.heading("Introduction", level=1)
+doc.paragraph("Hello world.")
+doc.render("report.docx")
+```
+
+---
+
+## Development Commands
+
+```bash
+# Setup
+pip install -e ".[dev]"
+
+# Tests
+pytest                                    # All tests
+pytest --cov=will --cov-report=html       # With coverage
+pytest tests/test_render.py               # Specific file
+
+# Linting
+black src tests
+ruff check src tests
+mypy src
+
+# Docs
+pip install -e ".[docs]"
+mkdocs serve                              # Local docs server
+
+# Build
+python -m build                           # Build package
+```
+
+## Code Style
+
+- Python 3.10+
+- Black formatter, Ruff linter, mypy for type checking
+- Type hints on all public functions
+- Docstrings on all public functions (Google style)
+- Tests for every public function
+- No print statements — use `logging` or `click.echo` in CLI
+
+## Key Design Decisions
+
+1. **Markdown is the source of truth.** All roads lead to Markdown. YAML specs compile to Markdown.
+   Programmatic API builds Markdown. The rendering pipeline always starts with Markdown.
+
+2. **Pandoc does the rendering.** We never write format-specific rendering code.
+   If Pandoc can't do it, we add a Lua filter. If a Lua filter can't do it, we preprocess the Markdown.
+
+3. **Preprocessing happens before Pandoc.** Data binding, variable substitution, includes, loops —
+   all resolved to plain Markdown before Pandoc sees it. Pandoc receives clean, standard Markdown.
+
+4. **Templates are Pandoc reference documents.** A "template" in Schopenhauer is a combination of:
+   a Pandoc reference doc (for docx), a defaults YAML (for Pandoc options), and optionally a
+   LaTeX/HTML template. We don't invent our own template format.
+
+5. **pypandoc_binary for zero-config.** Users should not need to install Pandoc separately.
+   The `pypandoc_binary` package bundles Pandoc. This is a hard requirement.
+
+6. **Backward compatibility via compilation.** The YAML/JSON spec format is supported indefinitely
+   by compiling it to Markdown. No user is left behind, but new docs should be Markdown.
+
+7. **Agent-friendly by design.** JSON Schema for all inputs. Stdin/stdout piping. MCP server.
+   REST API. Every interface an AI agent might need.
+
+## What NOT to Do
+
+- **Do not** add python-docx code or direct document manipulation
+- **Do not** write format-specific rendering logic (that's Pandoc's job)
+- **Do not** invent new Markdown syntax — use standard Pandoc Markdown extensions
+- **Do not** require Pandoc to be installed separately (use pypandoc_binary)
+- **Do not** break the legacy YAML spec input (compile it to Markdown instead)
+- **Do not** add heavy dependencies — keep the core light (pypandoc, jinja2, click, pyyaml)
+
+## Reference
+
+- [Pandoc User's Guide](https://pandoc.org/MANUAL.html)
+- [pypandoc](https://github.com/JessicaTegner/pypandoc)
+- [Pandoc Reference Docs](https://pandoc.org/MANUAL.html#option--reference-doc)
+- [Pandoc Lua Filters](https://pandoc.org/lua-filters.html)
+- [Pandoc Defaults Files](https://pandoc.org/MANUAL.html#defaults-files)
+- [Quarto](https://quarto.org) — inspiration for the architecture (Pandoc orchestration layer)
+- [Jinja2](https://jinja.palletsprojects.com/) — template engine for preprocessing

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Install Python dependencies
-COPY pyproject.toml .
+COPY pyproject.toml README.md ./
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir ".[api]"
 

--- a/examples/report.md
+++ b/examples/report.md
@@ -1,0 +1,103 @@
+---
+title: "{{COMPANY}} - Quarterly Report"
+subtitle: "{{QUARTER}}"
+author: "{{AUTHOR}}"
+will:
+  template: default
+  variables:
+    COMPANY: Acme Corporation
+    QUARTER: Q4 2024
+    AUTHOR: Jane Smith
+---
+
+# Executive Summary
+
+This quarterly report provides a comprehensive overview of
+{{COMPANY}}'s performance during {{QUARTER}}. Key highlights
+include strong revenue growth, improved operational efficiency,
+and successful execution of strategic initiatives.
+
+## Key Highlights
+
+- Revenue exceeded targets by 15%
+- Operating margin improved to 22%
+- Customer satisfaction reached all-time high
+- Successfully launched two new products
+
+# Financial Performance
+
+{{COMPANY}} delivered strong financial results this quarter,
+driven by robust demand and effective cost management.
+
+## Financial Summary
+
+| Metric | Target | Actual | Variance |
+| --- | --- | --- | --- |
+| Revenue | $10.0M | $11.5M | +15% |
+| Gross Profit | $6.0M | $7.2M | +20% |
+| Operating Income | $2.0M | $2.5M | +25% |
+| Net Income | $1.5M | $1.9M | +27% |
+
+## Revenue by Segment
+
+| Segment | Revenue | YoY Growth | % of Total |
+| --- | --- | --- | --- |
+| Enterprise | $5.0M | +18% | 43% |
+| Mid-Market | $3.5M | +12% | 30% |
+| SMB | $2.0M | +15% | 17% |
+| Services | $1.0M | +8% | 10% |
+
+# Operational Highlights
+
+## Product Development
+
+- Launched Product X with strong initial adoption
+- Completed beta testing for Product Y
+- Filed 3 new patents
+- Reduced development cycle time by 20%
+
+## Customer Success
+
+- Net Promoter Score improved to 72 (+8 from last quarter)
+- Customer retention rate at 95%
+- Reduced support ticket resolution time by 30%
+- Launched new customer success program
+
+## Team & Culture
+
+- Hired 25 new team members
+- Employee satisfaction score at 4.5/5.0
+- Launched leadership development program
+- Expanded remote work options
+
+# Strategic Initiatives
+
+Progress on key strategic initiatives remained strong this quarter,
+with significant milestones achieved across all focus areas.
+
+## Initiative Status
+
+| Initiative | Status | Progress | Target Date |
+| --- | --- | --- | --- |
+| Digital Transformation | On Track | 75% | Q2 2025 |
+| Market Expansion | Ahead | 90% | Q1 2025 |
+| Product Innovation | On Track | 60% | Q3 2025 |
+| Operational Excellence | On Track | 80% | Q4 2024 |
+
+# Outlook
+
+Looking ahead, {{COMPANY}} is well-positioned for continued growth.
+Management reaffirms guidance for the upcoming quarter and full year.
+
+## Next Quarter Priorities
+
+1. Complete Product Y launch
+2. Expand into two new geographic markets
+3. Achieve ISO 27001 certification
+4. Launch customer loyalty program
+
+> "We remain confident in our strategy and excited about the opportunities
+> ahead. Our team's dedication and our customers' trust continue to drive
+> our success."
+>
+> --- CEO, {{COMPANY}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,20 @@ build-backend = "hatchling.build"
 
 [project]
 name = "schopenhauer"
-version = "0.1.1"
-description = "A powerful CLI tool for generating Word documents from YAML/JSON specifications"
+version = "0.2.0"
+description = "A CLI tool and Python library for generating professional documents from Markdown sources"
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Yann Debray", email = "debray.yann@gmail.com"}
 ]
 keywords = [
     "docx",
-    "word",
+    "pdf",
+    "html",
+    "markdown",
+    "pandoc",
     "document",
     "generator",
     "cli",
@@ -30,7 +33,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -47,6 +49,7 @@ dependencies = [
     "pillow>=10.0.0",
     "httpx>=0.27.0",
     "jinja2>=3.0.0",
+    "pypandoc-binary>=1.15",
 ]
 
 [project.optional-dependencies]
@@ -88,6 +91,8 @@ include = [
     "/src",
     "/examples",
     "/tests",
+    "/templates",
+    "/schemas",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -100,11 +105,11 @@ addopts = "-v --cov=will --cov-report=term-missing"
 
 [tool.black]
 line-length = 100
-target-version = ["py39", "py310", "py311", "py312"]
+target-version = ["py310", "py311", "py312"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [
@@ -123,7 +128,7 @@ ignore = [
 ]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true

--- a/src/will/__init__.py
+++ b/src/will/__init__.py
@@ -1,24 +1,31 @@
 """
 Schopenhauer - The Will to Document
 
-A powerful CLI tool and Python library for generating Word documents
-from YAML/JSON specifications.
+A CLI tool and Python library for generating professional documents
+from Markdown sources.  Uses Pandoc as the rendering engine for
+multi-format output (docx, pdf, html, pptx, epub, …).
 
 Example:
-    >>> from will import WordDocument, DocumentBuilder
+    >>> from will import render
+    >>> render("report.md", output="report.docx")
+    >>> render("report.md", output="report.pdf", format="pdf")
+
+Legacy (python-docx) usage still works:
+    >>> from will import WordDocument
     >>> doc = WordDocument()
     >>> doc.add_heading("My Report", level=1)
-    >>> doc.add_paragraph("This is the introduction.")
     >>> doc.save("report.docx")
 
 CLI Usage:
-    $ will create -o report.docx --title "My Report"
-    $ will generate spec.yaml -o report.docx
+    $ will render report.md -o report.docx
+    $ will render report.md -o report.pdf -f pdf
+    $ will generate spec.yaml -o report.docx        # legacy
 """
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 __author__ = "Schopenhauer Contributors"
 
+from will.render import render
 from will.core import WordDocument
 from will.document import DocumentBuilder
 from will.styles import (
@@ -38,7 +45,9 @@ from will.templates import (
 __all__ = [
     # Version
     "__version__",
-    # Core classes
+    # Render pipeline (v0.2+)
+    "render",
+    # Core classes (legacy)
     "WordDocument",
     "DocumentBuilder",
     # Styles and configuration

--- a/src/will/__init__.py
+++ b/src/will/__init__.py
@@ -25,9 +25,9 @@ CLI Usage:
 __version__ = "0.2.0"
 __author__ = "Schopenhauer Contributors"
 
-from will.render import render
 from will.core import WordDocument
 from will.document import DocumentBuilder
+from will.render import render
 from will.styles import (
     BRAND,
     COLORS,

--- a/src/will/cli.py
+++ b/src/will/cli.py
@@ -76,6 +76,97 @@ def main(ctx, version):
 
 
 # =============================================================================
+# RENDER COMMAND (v0.2+ primary command)
+# =============================================================================
+
+
+@main.command()
+@click.argument("input_file", type=click.Path(exists=True))
+@click.option("--output", "-o", required=True, help="Output file path")
+@click.option(
+    "--format",
+    "-f",
+    "formats",
+    multiple=True,
+    help="Output format(s): docx, pdf, html, pptx, epub, latex. "
+    "Can be specified multiple times for multi-format output. "
+    "Inferred from output extension if not given.",
+)
+@click.option("--template", "-t", help="Template name or path to .docx reference doc")
+@click.option("--var", "-V", multiple=True, help="Variable substitution (KEY=VALUE)")
+@click.option(
+    "--backend",
+    type=click.Choice(["pandoc", "legacy"]),
+    default="pandoc",
+    help="Rendering backend (default: pandoc)",
+)
+def render(
+    input_file: str,
+    output: str,
+    formats: tuple,
+    template: Optional[str],
+    var: tuple,
+    backend: str,
+):
+    """
+    Render a Markdown or YAML/JSON spec to one or more output formats.
+
+    This is the primary document generation command (v0.2+).
+
+    \b
+    Examples:
+        will render report.md -o report.docx
+        will render report.md -o report.pdf -f pdf
+        will render report.md -o outputs/report -f docx -f pdf -f html
+        will render spec.yaml -o report.docx --backend legacy
+        will render report.md -o report.docx -V COMPANY="Acme" -V YEAR=2024
+        will render report.md -o report.docx -t report
+    """
+    from will.render import render as do_render
+
+    # Parse variables
+    variables = {}
+    for v in var:
+        if "=" in v:
+            key, value = v.split("=", 1)
+            variables[key] = value
+
+    try:
+        output_path = Path(output)
+
+        if formats:
+            # Multi-format: generate one file per format
+            for fmt in formats:
+                if len(formats) > 1:
+                    out = output_path.parent / f"{output_path.stem}.{fmt}"
+                else:
+                    out = output_path
+                do_render(
+                    source=input_file,
+                    output=str(out),
+                    format=fmt,
+                    template=template,
+                    variables=variables,
+                    backend=backend,
+                )
+                click.echo(click.style(f"  Rendered: {out}", fg="green"))
+        else:
+            # Single format (inferred from extension)
+            do_render(
+                source=input_file,
+                output=str(output_path),
+                template=template,
+                variables=variables,
+                backend=backend,
+            )
+            click.echo(click.style(f"  Rendered: {output_path}", fg="green"))
+
+    except Exception as e:
+        click.echo(click.style(f"Error rendering document: {e}", fg="red"), err=True)
+        sys.exit(1)
+
+
+# =============================================================================
 # CREATE COMMAND
 # =============================================================================
 

--- a/src/will/pandoc_backend.py
+++ b/src/will/pandoc_backend.py
@@ -1,0 +1,140 @@
+"""Pandoc backend — thin wrapper around pypandoc.
+
+All actual document rendering goes through Pandoc.  This module provides
+a clean interface for the rest of Schopenhauer to call into Pandoc without
+knowing the details of pypandoc's API.
+"""
+
+import logging
+import tempfile
+from pathlib import Path
+
+import pypandoc
+
+logger = logging.getLogger(__name__)
+
+
+class PandocBackendError(Exception):
+    """Raised when a Pandoc conversion fails."""
+
+
+# Format aliases: map short names to Pandoc format identifiers
+_FORMAT_ALIASES: dict[str, str] = {
+    "docx": "docx",
+    "pdf": "pdf",
+    "html": "html",
+    "pptx": "pptx",
+    "epub": "epub",
+    "latex": "latex",
+    "tex": "latex",
+    "odt": "odt",
+    "rtf": "rtf",
+    "md": "markdown",
+    "markdown": "markdown",
+}
+
+
+def _resolve_format(fmt: str) -> str:
+    return _FORMAT_ALIASES.get(fmt.lower(), fmt)
+
+
+def convert(
+    source: str,
+    output_path: str | Path,
+    output_format: str = "docx",
+    reference_doc: str | Path | None = None,
+    extra_args: list[str] | None = None,
+    metadata: dict | None = None,
+) -> Path:
+    """Convert a Markdown string to the target format via Pandoc.
+
+    Args:
+        source: Markdown content (string).
+        output_path: Destination file path.
+        output_format: Target format (``docx``, ``pdf``, ``html``, etc.).
+        reference_doc: Path to a Pandoc reference doc (``.docx``).
+        extra_args: Additional CLI arguments forwarded to Pandoc.
+        metadata: Key-value metadata pairs passed via ``-M key=value``.
+
+    Returns:
+        The resolved output ``Path``.
+
+    Raises:
+        PandocBackendError: If Pandoc returns a non-zero exit code.
+    """
+    output_path = Path(output_path)
+    fmt = _resolve_format(output_format)
+
+    args: list[str] = list(extra_args or [])
+    args.append("--standalone")
+
+    # Format-specific defaults
+    if fmt == "pdf":
+        if not any(a.startswith("--pdf-engine") for a in args):
+            args.append("--pdf-engine=xelatex")
+    if fmt == "html":
+        if not any(a.startswith("--self-contained") or a == "--embed-resources" for a in args):
+            args.append("--embed-resources")
+
+    if reference_doc:
+        args.extend(["--reference-doc", str(reference_doc)])
+
+    if metadata:
+        for key, value in metadata.items():
+            args.extend(["-M", f"{key}={value}"])
+
+    try:
+        pypandoc.convert_text(
+            source,
+            fmt,
+            format="markdown",
+            outputfile=str(output_path),
+            extra_args=args,
+        )
+    except RuntimeError as exc:
+        raise PandocBackendError(f"Pandoc conversion failed: {exc}") from exc
+
+    return output_path
+
+
+def convert_to_bytes(
+    source: str,
+    output_format: str = "docx",
+    reference_doc: str | Path | None = None,
+    extra_args: list[str] | None = None,
+    metadata: dict | None = None,
+) -> bytes:
+    """Convert Markdown to the target format and return raw bytes.
+
+    Same parameters as :func:`convert` but returns ``bytes`` instead of
+    writing to a file.
+    """
+    suffix = f".{output_format}" if not output_format.startswith(".") else output_format
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        convert(
+            source,
+            tmp_path,
+            output_format=output_format,
+            reference_doc=reference_doc,
+            extra_args=extra_args,
+            metadata=metadata,
+        )
+        return tmp_path.read_bytes()
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def get_pandoc_version() -> str:
+    """Return the Pandoc version string."""
+    return pypandoc.get_pandoc_version()
+
+
+def get_supported_formats() -> dict[str, list[str]]:
+    """Return a dict with ``input`` and ``output`` format lists."""
+    return {
+        "input": pypandoc.get_pandoc_formats()[0],
+        "output": pypandoc.get_pandoc_formats()[1],
+    }

--- a/src/will/preprocess.py
+++ b/src/will/preprocess.py
@@ -1,0 +1,63 @@
+"""Preprocessing engine for Schopenhauer.
+
+Handles variable substitution and template directives in Markdown content
+before passing to Pandoc. Uses Jinja2 under the hood with permissive
+undefined handling so unresolved variables pass through unchanged.
+"""
+
+import logging
+
+from jinja2 import BaseLoader, Environment, Undefined
+
+logger = logging.getLogger(__name__)
+
+
+class PreprocessError(Exception):
+    """Raised when preprocessing fails."""
+
+
+class _PassthroughUndefined(Undefined):
+    """Jinja2 Undefined subclass that renders back to ``{{name}}``."""
+
+    def __str__(self) -> str:
+        return "{{" + self._undefined_name + "}}"
+
+    def __iter__(self):
+        return iter([])
+
+    def __bool__(self) -> bool:
+        return False
+
+
+def preprocess(content: str, variables: dict | None = None) -> str:
+    """Preprocess Markdown content with variable substitution.
+
+    Replaces ``{{var}}`` tokens in *content* with values from *variables*.
+    Unresolved tokens are left as-is (passthrough) for backward compatibility.
+
+    Args:
+        content: Raw Markdown string (may contain ``{{var}}`` tokens).
+        variables: Mapping of variable names to replacement values.
+
+    Returns:
+        The processed Markdown string.
+
+    Raises:
+        PreprocessError: If Jinja2 rendering fails for a reason other than
+            missing variables (e.g. syntax error in a directive).
+    """
+    if variables is None:
+        variables = {}
+
+    # Use Jinja2 with {{ }} delimiters (the default) and passthrough undefined
+    env = Environment(
+        loader=BaseLoader(),
+        undefined=_PassthroughUndefined,
+        keep_trailing_newline=True,
+    )
+
+    try:
+        template = env.from_string(content)
+        return template.render(**variables)
+    except Exception as exc:
+        raise PreprocessError(f"Preprocessing failed: {exc}") from exc

--- a/src/will/render.py
+++ b/src/will/render.py
@@ -1,0 +1,222 @@
+"""Render pipeline — the main entry point for document generation.
+
+Orchestrates: input detection → spec compilation → frontmatter extraction →
+variable preprocessing → Pandoc conversion.
+"""
+
+import logging
+import re
+from pathlib import Path
+
+import yaml
+
+from will.pandoc_backend import convert as pandoc_convert
+from will.pandoc_backend import convert_to_bytes as pandoc_convert_to_bytes
+from will.preprocess import preprocess
+from will.spec_compiler import compile_spec_file
+
+logger = logging.getLogger(__name__)
+
+# Where Pandoc reference docs are located (relative to the package root).
+_TEMPLATES_DIR = Path(__file__).resolve().parent.parent.parent / "templates"
+
+# Regex for YAML frontmatter delimiters (leading ``---``)
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?\n)---\n", re.DOTALL)
+
+
+class RenderError(Exception):
+    """Raised when the render pipeline fails."""
+
+
+def render(
+    source: str | Path,
+    output: str | Path | None = None,
+    format: str | None = None,
+    template: str | None = None,
+    variables: dict | None = None,
+    backend: str = "pandoc",
+) -> Path | bytes:
+    """Render a document from Markdown or a legacy spec file.
+
+    Args:
+        source: Path to a ``.md``, ``.yaml``, ``.yml``, or ``.json`` file,
+            or a raw Markdown string (detected by the absence of a file
+            extension on disk).
+        output: Destination file path.  When *None*, raw bytes are returned.
+        format: Output format (``docx``, ``pdf``, ``html``, …).
+            Inferred from *output* extension when omitted.
+        template: Template name (resolved to ``templates/reference-docs/<name>.docx``)
+            or an absolute/relative path to a ``.docx`` reference doc.
+        variables: Extra variables for ``{{var}}`` substitution.
+        backend: ``"pandoc"`` (default) or ``"legacy"`` (python-docx).
+
+    Returns:
+        The output ``Path`` when *output* is given, otherwise ``bytes``.
+
+    Raises:
+        RenderError: On any failure in the pipeline.
+    """
+    variables = dict(variables or {})
+
+    # --- Legacy backend shortcut ---------------------------------------------
+    if backend == "legacy":
+        return _render_legacy(source, output, variables)
+
+    # --- Determine Markdown content ------------------------------------------
+    source_path = Path(source) if not isinstance(source, Path) else source
+
+    if source_path.is_file():
+        suffix = source_path.suffix.lower()
+        if suffix in (".yaml", ".yml", ".json"):
+            markdown = compile_spec_file(source_path)
+        else:
+            markdown = source_path.read_text(encoding="utf-8")
+    elif source_path.suffix and not source_path.is_file():
+        # Looks like a file path (has extension) but doesn't exist
+        raise RenderError(f"Source not found: {source}")
+    elif isinstance(source, str):
+        # Treat as raw Markdown string
+        markdown = source
+    else:
+        raise RenderError(f"Source not found: {source}")
+
+    # --- Extract frontmatter -------------------------------------------------
+    frontmatter, body = _extract_frontmatter(markdown)
+
+    # --- Merge variables -----------------------------------------------------
+    will_meta = frontmatter.get("will", {}) or {}
+    fm_vars = will_meta.get("variables", {}) or {}
+    merged_vars = {**fm_vars, **variables}
+
+    # --- Preprocess ----------------------------------------------------------
+    body = preprocess(body, merged_vars)
+
+    # --- Resolve output format -----------------------------------------------
+    if format is None and output is not None:
+        format = Path(output).suffix.lstrip(".")
+    if format is None:
+        format = "docx"
+
+    # --- Resolve template / reference doc ------------------------------------
+    template_name = template or will_meta.get("template")
+    reference_doc = _resolve_template(template_name, format)
+
+    # --- Rebuild full Markdown (frontmatter + processed body) ----------------
+    final_md = _rebuild_markdown(frontmatter, body)
+
+    # --- Convert via Pandoc --------------------------------------------------
+    try:
+        if output is not None:
+            return pandoc_convert(
+                final_md,
+                output_path=output,
+                output_format=format,
+                reference_doc=reference_doc,
+            )
+        else:
+            return pandoc_convert_to_bytes(
+                final_md,
+                output_format=format,
+                reference_doc=reference_doc,
+            )
+    except Exception as exc:
+        raise RenderError(f"Render failed: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _extract_frontmatter(markdown: str) -> tuple[dict, str]:
+    """Split YAML frontmatter from the Markdown body.
+
+    Returns:
+        ``(frontmatter_dict, body_string)``
+    """
+    match = _FRONTMATTER_RE.match(markdown)
+    if not match:
+        return {}, markdown
+
+    raw_fm = match.group(1)
+    body = markdown[match.end():]
+
+    try:
+        fm = yaml.safe_load(raw_fm) or {}
+    except yaml.YAMLError:
+        logger.warning("Invalid YAML frontmatter, ignoring")
+        fm = {}
+
+    return fm, body
+
+
+def _resolve_template(name: str | None, format: str) -> Path | None:
+    """Map a template *name* to a reference-doc path.
+
+    Resolution order:
+    1. If *name* is ``None``, return ``None`` (Pandoc defaults).
+    2. If *name* is an existing file path, use it directly.
+    3. Look up ``templates/reference-docs/<name>.docx`` (for docx format).
+    """
+    if name is None:
+        return None
+
+    # Direct path?
+    p = Path(name)
+    if p.is_file():
+        return p
+
+    # Only docx templates for now
+    if format == "docx":
+        candidate = _TEMPLATES_DIR / "reference-docs" / f"{name}.docx"
+        if candidate.is_file():
+            return candidate
+
+    return None
+
+
+def _rebuild_markdown(frontmatter: dict, body: str) -> str:
+    """Reconstruct Markdown with YAML frontmatter for Pandoc.
+
+    Only standard Pandoc fields are forwarded (title, subtitle, author, date,
+    lang, …).  The ``will:`` namespace is stripped because Pandoc doesn't
+    understand it.
+    """
+    # Fields that Pandoc understands natively
+    pandoc_keys = {"title", "subtitle", "author", "date", "lang", "abstract", "keywords"}
+    pandoc_fm = {k: v for k, v in frontmatter.items() if k in pandoc_keys}
+
+    if pandoc_fm:
+        header = "---\n" + yaml.dump(pandoc_fm, default_flow_style=False, allow_unicode=True).rstrip() + "\n---\n\n"
+    else:
+        header = ""
+
+    return header + body
+
+
+def _render_legacy(
+    source: str | Path,
+    output: str | Path | None,
+    variables: dict,
+) -> Path | bytes:
+    """Fallback to the python-docx legacy backend."""
+    import json as _json
+
+    from will.core import WordDocument
+
+    source_path = Path(source)
+    if source_path.suffix.lower() in (".yaml", ".yml"):
+        doc = WordDocument.from_yaml(str(source_path))
+    elif source_path.suffix.lower() == ".json":
+        doc = WordDocument.from_json(str(source_path))
+    else:
+        raise RenderError(
+            "Legacy backend only supports .yaml/.json specs, not Markdown."
+        )
+
+    if variables:
+        doc.replace_placeholders(variables)
+
+    if output is not None:
+        doc.save(output)
+        return Path(output)
+    return doc.to_bytes()

--- a/src/will/spec_compiler.py
+++ b/src/will/spec_compiler.py
@@ -1,0 +1,227 @@
+"""Spec compiler — converts legacy YAML/JSON specs to Markdown.
+
+The legacy spec format (v0.1.x) uses a ``sections`` array to describe
+document structure.  This module compiles that format into Markdown with
+YAML frontmatter so the rest of the pipeline only needs to deal with
+Markdown.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class SpecCompileError(Exception):
+    """Raised when a spec cannot be compiled to Markdown."""
+
+
+def compile_spec(spec: dict) -> str:
+    """Compile a legacy spec dictionary to Markdown with YAML frontmatter.
+
+    Args:
+        spec: A document specification dict (as loaded from YAML/JSON).
+
+    Returns:
+        A Markdown string with YAML frontmatter.
+    """
+    parts: list[str] = []
+
+    # --- Build frontmatter ---------------------------------------------------
+    fm: dict = {}
+    for key in ("title", "subtitle", "author", "date"):
+        if key in spec:
+            fm[key] = spec[key]
+
+    will_meta: dict = {}
+    if spec.get("page_size"):
+        will_meta["page_size"] = spec["page_size"]
+    if spec.get("margins"):
+        will_meta["margins"] = spec["margins"]
+    if spec.get("header"):
+        will_meta["header"] = spec["header"]
+    if spec.get("footer"):
+        will_meta["footer"] = spec["footer"]
+    if spec.get("table_of_contents"):
+        will_meta["table_of_contents"] = True
+    if spec.get("template"):
+        will_meta["template"] = spec["template"]
+
+    if will_meta:
+        fm["will"] = will_meta
+
+    if fm:
+        parts.append("---")
+        parts.append(yaml.dump(fm, default_flow_style=False, allow_unicode=True).rstrip())
+        parts.append("---")
+        parts.append("")
+
+    # --- Compile sections -----------------------------------------------------
+    for section in spec.get("sections", []):
+        md = _compile_section(section)
+        if md:
+            parts.append(md)
+
+    return "\n".join(parts) + "\n"
+
+
+def compile_spec_file(path: str | Path) -> str:
+    """Load a YAML or JSON spec file and compile to Markdown.
+
+    Args:
+        path: Path to a ``.yaml``, ``.yml``, or ``.json`` file.
+
+    Returns:
+        Compiled Markdown string.
+
+    Raises:
+        SpecCompileError: If the file cannot be read or parsed.
+    """
+    path = Path(path)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SpecCompileError(f"Cannot read spec file: {exc}") from exc
+
+    try:
+        if path.suffix.lower() in (".yaml", ".yml"):
+            spec = yaml.safe_load(text)
+        else:
+            spec = json.loads(text)
+    except Exception as exc:
+        raise SpecCompileError(f"Cannot parse spec file: {exc}") from exc
+
+    if not isinstance(spec, dict):
+        raise SpecCompileError("Spec must be a YAML/JSON object (dict)")
+
+    return compile_spec(spec)
+
+
+# ---------------------------------------------------------------------------
+# Section compilers
+# ---------------------------------------------------------------------------
+
+def _compile_section(section: dict) -> str:
+    """Compile a single spec section dict to Markdown."""
+    section_type = section.get("type", "content")
+    compiler = _SECTION_COMPILERS.get(section_type)
+    if compiler is None:
+        logger.warning("Unknown section type '%s', skipping", section_type)
+        return ""
+    return compiler(section)
+
+
+def _heading(sec: dict) -> str:
+    level = sec.get("level", 1)
+    title = sec.get("title", "")
+    prefix = "#" * level
+    return f"{prefix} {title}\n"
+
+
+def _section(sec: dict) -> str:
+    parts: list[str] = []
+    if sec.get("page_break"):
+        parts.append("\\newpage\n")
+    title = sec.get("title", "")
+    parts.append(f"# {title}\n")
+    if sec.get("subtitle"):
+        parts.append(f"*{sec['subtitle']}*\n")
+    return "\n".join(parts)
+
+
+def _content(sec: dict) -> str:
+    parts: list[str] = []
+    if sec.get("title"):
+        level = sec.get("level", 2)
+        prefix = "#" * level
+        parts.append(f"{prefix} {sec['title']}\n")
+    if sec.get("text"):
+        parts.append(sec["text"].rstrip() + "\n")
+    if sec.get("bullets"):
+        for item in sec["bullets"]:
+            parts.append(f"- {item}")
+        parts.append("")
+    if sec.get("numbered"):
+        for i, item in enumerate(sec["numbered"], 1):
+            parts.append(f"{i}. {item}")
+        parts.append("")
+    return "\n".join(parts)
+
+
+def _table(sec: dict) -> str:
+    parts: list[str] = []
+    if sec.get("title"):
+        level = sec.get("level", 2)
+        prefix = "#" * level
+        parts.append(f"{prefix} {sec['title']}\n")
+
+    headers: list[str] = sec.get("headers", [])
+    data: list[list] = sec.get("data", [])
+
+    if headers:
+        parts.append("| " + " | ".join(str(h) for h in headers) + " |")
+        parts.append("| " + " | ".join("---" for _ in headers) + " |")
+
+    for row in data:
+        parts.append("| " + " | ".join(str(c) for c in row) + " |")
+
+    parts.append("")
+    return "\n".join(parts)
+
+
+def _image(sec: dict) -> str:
+    path = sec.get("path", sec.get("image", ""))
+    caption = sec.get("caption", sec.get("title", ""))
+    width = sec.get("width")
+    md = f"![{caption}]({path})"
+    if width:
+        md += f"{{ width={width}in }}"
+    return md + "\n"
+
+
+def _quote(sec: dict) -> str:
+    text = sec.get("text", "")
+    author = sec.get("author")
+    parts = [f'> "{text}"']
+    if author:
+        parts.append(f"> --- {author}")
+    parts.append("")
+    return "\n".join(parts)
+
+
+def _code(sec: dict) -> str:
+    parts: list[str] = []
+    if sec.get("title"):
+        level = sec.get("level", 3)
+        prefix = "#" * level
+        parts.append(f"{prefix} {sec['title']}\n")
+    language = sec.get("language", "")
+    code = sec.get("code", sec.get("text", ""))
+    parts.append(f"```{language}")
+    parts.append(code.rstrip())
+    parts.append("```\n")
+    return "\n".join(parts)
+
+
+def _page_break(_sec: dict) -> str:
+    return "\\newpage\n"
+
+
+def _horizontal_line(_sec: dict) -> str:
+    return "---\n"
+
+
+_SECTION_COMPILERS = {
+    "heading": _heading,
+    "section": _section,
+    "content": _content,
+    "table": _table,
+    "image": _image,
+    "quote": _quote,
+    "code": _code,
+    "page_break": _page_break,
+    "horizontal_line": _horizontal_line,
+}

--- a/templates/defaults/docx.yaml
+++ b/templates/defaults/docx.yaml
@@ -1,0 +1,3 @@
+from: markdown
+to: docx
+standalone: true

--- a/templates/defaults/html.yaml
+++ b/templates/defaults/html.yaml
@@ -1,0 +1,4 @@
+from: markdown
+to: html
+standalone: true
+embed-resources: true

--- a/templates/defaults/pdf.yaml
+++ b/templates/defaults/pdf.yaml
@@ -1,0 +1,6 @@
+from: markdown
+to: pdf
+standalone: true
+pdf-engine: xelatex
+variables:
+  geometry: margin=1in

--- a/tests/test_pandoc_backend.py
+++ b/tests/test_pandoc_backend.py
@@ -1,0 +1,76 @@
+"""Tests for the Pandoc backend wrapper."""
+
+import os
+import tempfile
+
+import pytest
+
+from will.pandoc_backend import (
+    PandocBackendError,
+    convert,
+    convert_to_bytes,
+    get_pandoc_version,
+    get_supported_formats,
+)
+
+
+class TestGetPandocVersion:
+    def test_returns_string(self):
+        version = get_pandoc_version()
+        assert isinstance(version, str)
+        assert len(version) > 0
+
+
+class TestGetSupportedFormats:
+    def test_returns_dict(self):
+        fmts = get_supported_formats()
+        assert "input" in fmts
+        assert "output" in fmts
+        assert "markdown" in fmts["input"]
+        assert "docx" in fmts["output"]
+
+
+class TestConvert:
+    def test_markdown_to_docx(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = os.path.join(tmpdir, "test.docx")
+            result = convert("# Hello\n\nWorld", out, output_format="docx")
+            assert result.exists()
+            assert result.stat().st_size > 0
+
+    def test_markdown_to_html(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = os.path.join(tmpdir, "test.html")
+            result = convert("# Hello\n\nWorld", out, output_format="html")
+            assert result.exists()
+            content = result.read_text(encoding="utf-8")
+            assert "Hello" in content
+
+    def test_with_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = os.path.join(tmpdir, "test.html")
+            convert(
+                "# Doc\n\nBody",
+                out,
+                output_format="html",
+                metadata={"title": "My Title"},
+            )
+            content = open(out, encoding="utf-8").read()
+            assert "My Title" in content
+
+    def test_invalid_format(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = os.path.join(tmpdir, "test.xyz")
+            with pytest.raises(PandocBackendError):
+                convert("# Hello", out, output_format="not_a_format_xyz")
+
+
+class TestConvertToBytes:
+    def test_returns_bytes(self):
+        data = convert_to_bytes("# Hello\n\nWorld", output_format="docx")
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+
+    def test_html_bytes(self):
+        data = convert_to_bytes("# Hello", output_format="html")
+        assert b"Hello" in data

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,55 @@
+"""Tests for the preprocessing engine."""
+
+import pytest
+
+from will.preprocess import PreprocessError, preprocess
+
+
+class TestPreprocess:
+    """Tests for variable substitution."""
+
+    def test_no_variables(self):
+        assert preprocess("Hello world") == "Hello world"
+
+    def test_simple_substitution(self):
+        result = preprocess("Hello {{name}}", {"name": "World"})
+        assert result == "Hello World"
+
+    def test_multiple_variables(self):
+        result = preprocess(
+            "{{greeting}}, {{name}}!",
+            {"greeting": "Hi", "name": "Alice"},
+        )
+        assert result == "Hi, Alice!"
+
+    def test_unresolved_passthrough(self):
+        """Unresolved variables should pass through as {{name}}."""
+        result = preprocess("Hello {{unknown}}")
+        assert result == "Hello {{unknown}}"
+
+    def test_partial_resolution(self):
+        """Resolved vars replaced, unresolved vars kept."""
+        result = preprocess(
+            "{{resolved}} and {{unresolved}}",
+            {"resolved": "YES"},
+        )
+        assert result == "YES and {{unresolved}}"
+
+    def test_empty_content(self):
+        assert preprocess("") == ""
+
+    def test_none_variables(self):
+        result = preprocess("Hello {{x}}", None)
+        assert result == "Hello {{x}}"
+
+    def test_preserves_markdown(self):
+        md = "# Title\n\n**bold** and *italic*\n\n- bullet\n"
+        assert preprocess(md) == md
+
+    def test_preserves_trailing_newline(self):
+        result = preprocess("line\n", {})
+        assert result.endswith("\n")
+
+    def test_numeric_value(self):
+        result = preprocess("Year: {{year}}", {"year": 2024})
+        assert result == "Year: 2024"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,121 @@
+"""Tests for the render pipeline."""
+
+import os
+import tempfile
+
+import pytest
+
+from will.render import RenderError, render
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
+
+
+@pytest.fixture
+def sample_md(temp_dir):
+    """Create a sample Markdown file."""
+    path = os.path.join(temp_dir, "sample.md")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(
+            "---\n"
+            "title: Test Document\n"
+            "author: Tester\n"
+            "will:\n"
+            "  variables:\n"
+            "    greeting: Hello\n"
+            "---\n\n"
+            "# {{greeting}} World\n\n"
+            "This is a test document.\n"
+        )
+    return path
+
+
+@pytest.fixture
+def sample_yaml(temp_dir):
+    """Create a sample YAML spec file."""
+    path = os.path.join(temp_dir, "sample.yaml")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(
+            "title: YAML Document\n"
+            "sections:\n"
+            "  - type: heading\n"
+            "    title: Introduction\n"
+            "    level: 1\n"
+            "  - type: content\n"
+            "    text: This is from a YAML spec.\n"
+        )
+    return path
+
+
+class TestRenderMarkdownToDocx:
+    def test_basic(self, sample_md, temp_dir):
+        out = os.path.join(temp_dir, "out.docx")
+        result = render(sample_md, output=out)
+        assert result.exists()
+        assert result.stat().st_size > 0
+
+    def test_returns_bytes_when_no_output(self, sample_md):
+        data = render(sample_md)
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+
+
+class TestRenderMarkdownToHtml:
+    def test_html_output(self, sample_md, temp_dir):
+        out = os.path.join(temp_dir, "out.html")
+        result = render(sample_md, output=out, format="html")
+        assert result.exists()
+        content = result.read_text(encoding="utf-8")
+        assert "Hello World" in content
+
+
+class TestRenderYamlSpec:
+    def test_yaml_to_docx(self, sample_yaml, temp_dir):
+        out = os.path.join(temp_dir, "out.docx")
+        result = render(sample_yaml, output=out)
+        assert result.exists()
+        assert result.stat().st_size > 0
+
+
+class TestRenderWithVariables:
+    def test_cli_variables_override(self, temp_dir):
+        """CLI variables should override frontmatter variables."""
+        md_path = os.path.join(temp_dir, "vars.md")
+        with open(md_path, "w", encoding="utf-8") as f:
+            f.write(
+                "---\n"
+                "title: Vars Test\n"
+                "will:\n"
+                "  variables:\n"
+                "    name: Default\n"
+                "---\n\n"
+                "Hello {{name}}\n"
+            )
+        out = os.path.join(temp_dir, "out.html")
+        result = render(md_path, output=out, format="html", variables={"name": "Override"})
+        content = result.read_text(encoding="utf-8")
+        assert "Override" in content
+        assert "Default" not in content
+
+
+class TestRenderLegacyBackend:
+    def test_legacy_yaml(self, sample_yaml, temp_dir):
+        out = os.path.join(temp_dir, "legacy.docx")
+        result = render(sample_yaml, output=out, backend="legacy")
+        assert result.exists()
+        assert result.stat().st_size > 0
+
+    def test_legacy_rejects_markdown(self, sample_md, temp_dir):
+        out = os.path.join(temp_dir, "legacy.docx")
+        with pytest.raises(RenderError):
+            render(sample_md, output=out, backend="legacy")
+
+
+class TestRenderErrors:
+    def test_nonexistent_source(self, temp_dir):
+        out = os.path.join(temp_dir, "out.docx")
+        with pytest.raises(RenderError):
+            render("/nonexistent/file.md", output=out)

--- a/tests/test_spec_compiler.py
+++ b/tests/test_spec_compiler.py
@@ -1,0 +1,175 @@
+"""Tests for the spec compiler (legacy YAML/JSON → Markdown)."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from will.spec_compiler import SpecCompileError, compile_spec, compile_spec_file
+
+
+class TestCompileSpec:
+    """Tests for compile_spec()."""
+
+    def test_minimal_spec(self):
+        md = compile_spec({"title": "Hello"})
+        assert "title: Hello" in md
+
+    def test_frontmatter_fields(self):
+        md = compile_spec({
+            "title": "Title",
+            "subtitle": "Sub",
+            "author": "Author",
+        })
+        assert "title:" in md
+        assert "subtitle:" in md
+        assert "author:" in md
+
+    def test_will_metadata(self):
+        md = compile_spec({
+            "title": "T",
+            "page_size": "a4",
+            "margins": "narrow",
+            "template": "report",
+        })
+        assert "will:" in md
+        assert "page_size: a4" in md
+
+    def test_heading_section(self):
+        md = compile_spec({
+            "sections": [
+                {"type": "heading", "title": "My Heading", "level": 2},
+            ],
+        })
+        assert "## My Heading" in md
+
+    def test_section_with_page_break(self):
+        md = compile_spec({
+            "sections": [
+                {"type": "section", "title": "Chapter", "page_break": True},
+            ],
+        })
+        assert "\\newpage" in md
+        assert "# Chapter" in md
+
+    def test_section_with_subtitle(self):
+        md = compile_spec({
+            "sections": [
+                {"type": "section", "title": "Ch", "subtitle": "Sub"},
+            ],
+        })
+        assert "*Sub*" in md
+
+    def test_content_with_text(self):
+        md = compile_spec({
+            "sections": [
+                {"type": "content", "text": "Hello world"},
+            ],
+        })
+        assert "Hello world" in md
+
+    def test_content_with_bullets(self):
+        md = compile_spec({
+            "sections": [
+                {"type": "content", "bullets": ["A", "B", "C"]},
+            ],
+        })
+        assert "- A" in md
+        assert "- B" in md
+        assert "- C" in md
+
+    def test_content_with_numbered(self):
+        md = compile_spec({
+            "sections": [
+                {"type": "content", "numbered": ["First", "Second"]},
+            ],
+        })
+        assert "1. First" in md
+        assert "2. Second" in md
+
+    def test_table(self):
+        md = compile_spec({
+            "sections": [
+                {
+                    "type": "table",
+                    "title": "Data",
+                    "headers": ["Col1", "Col2"],
+                    "data": [["a", "b"], ["c", "d"]],
+                },
+            ],
+        })
+        assert "| Col1 | Col2 |" in md
+        assert "| a | b |" in md
+
+    def test_image(self):
+        md = compile_spec({
+            "sections": [
+                {"type": "image", "path": "fig.png", "caption": "Figure 1", "width": 5},
+            ],
+        })
+        assert "![Figure 1](fig.png)" in md
+        assert "width=5in" in md
+
+    def test_quote(self):
+        md = compile_spec({
+            "sections": [
+                {"type": "quote", "text": "To be", "author": "Shakespeare"},
+            ],
+        })
+        assert '> "To be"' in md
+        assert "Shakespeare" in md
+
+    def test_code(self):
+        md = compile_spec({
+            "sections": [
+                {"type": "code", "code": "print('hi')", "language": "python"},
+            ],
+        })
+        assert "```python" in md
+        assert "print('hi')" in md
+
+    def test_page_break(self):
+        md = compile_spec({
+            "sections": [{"type": "page_break"}],
+        })
+        assert "\\newpage" in md
+
+    def test_horizontal_line(self):
+        md = compile_spec({
+            "sections": [{"type": "horizontal_line"}],
+        })
+        assert "---" in md
+
+    def test_empty_sections(self):
+        md = compile_spec({"sections": []})
+        assert md.strip() == ""
+
+
+class TestCompileSpecFile:
+    """Tests for compile_spec_file()."""
+
+    def test_yaml_file(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+        ) as f:
+            f.write("title: Test\nsections:\n  - type: heading\n    title: Hello\n    level: 1\n")
+            f.flush()
+            md = compile_spec_file(f.name)
+        os.unlink(f.name)
+        assert "# Hello" in md
+
+    def test_json_file(self):
+        spec = {"title": "JSON Test", "sections": [{"type": "content", "text": "body"}]}
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as f:
+            json.dump(spec, f)
+            f.flush()
+            md = compile_spec_file(f.name)
+        os.unlink(f.name)
+        assert "body" in md
+
+    def test_nonexistent_file(self):
+        with pytest.raises(SpecCompileError):
+            compile_spec_file("/nonexistent/file.yaml")


### PR DESCRIPTION
## Summary

- Introduces Pandoc backend via `pypandoc_binary` for multi-format document rendering (docx, pdf, html, etc.)
- Adds Markdown with YAML frontmatter as the new source format, with preprocessing support for variables and data binding
- Implements spec compiler to maintain backward compatibility with legacy YAML/JSON specs by compiling them to Markdown
- Includes comprehensive test suite for the new rendering pipeline

## Test plan

- [ ] Run `pytest` to verify all new tests pass
- [ ] Test `will render examples/report.md -o report.docx` produces valid output
- [ ] Verify legacy YAML specs still work via the spec compiler
- [ ] Test multi-format output with `-f docx -f pdf` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)